### PR TITLE
improved lcluster init

### DIFF
--- a/distant_stars_overhaul_original/common/solar_system_initializers/distant_stars_initializer.txt
+++ b/distant_stars_overhaul_original/common/solar_system_initializers/distant_stars_initializer.txt
@@ -1,0 +1,807 @@
+### L-Cluster init (bit opt. by FirePrince)
+@base_moon_distance = 10
+
+# L-Gate System
+distantstars_init_00 = {
+	class = sc_black_hole
+	flags = { hostile_system lgate }
+	usage = misc_system_init
+	usage_odds = {
+		base = 0
+		modifier = {
+			no_scope = { has_distar = yes }
+			add = 2
+		}
+		modifier = {
+			factor = 0
+			is_fe_cluster = yes
+		}
+		modifier = {
+			factor = 0
+			has_star_flag = empire_cluster
+		}
+		modifier = {
+			factor = 0
+			any_neighbor_system = {
+				OR = {
+ 					has_megastructure = lgate_base
+					has_megastructure = gateway_ruined
+				}
+			}
+		}
+	}
+	max_instances = 9
+	scaled_spawn_chance = 10
+	planet = {
+		class = star
+		orbit_distance = 0
+	}
+	change_orbit = 60
+	planet = {
+		count = { min = 0 max = 1 }
+		class = "pc_broken"
+		size = { min = 10 max = 15 }
+		init_effect = { prevent_anomaly = yes }
+	}
+	change_orbit = 30
+	planet = {
+		count = { min = 0 max = 1 }
+		class = "pc_barren_cold"
+		size = { min = 10 max = 20 }
+	}
+	init_effect = {
+		spawn_megastructure = {
+			type = lgate_base
+			orbit_angle = 225
+			orbit_distance = 30
+			location = solar_system
+		}
+	}
+}
+
+# Guaranteed L-Gate spawn
+distantstars_init_06 = {
+	class = sc_black_hole
+	flags = { hostile_system lgate lgate_guaranteed }
+	usage = misc_system_init
+	usage_odds = {
+		base = 0
+		modifier = {
+			no_scope = { has_distar = yes }
+			add = 99999
+		}
+		modifier = {
+			factor = 0
+			is_fe_cluster = yes
+		}
+		modifier = {
+			factor = 0
+			has_star_flag = empire_cluster
+		}
+		modifier = {
+			factor = 0
+			any_neighbor_system = {
+				OR = {
+ 					has_megastructure = lgate_base
+					has_megastructure = gateway_ruined
+				}
+			}
+		}
+	}
+	max_instances = 1
+	spawn_chance = 100
+	planet = {
+		class = star
+		orbit_distance = 0
+	}
+	change_orbit = 60
+	planet = {
+		count = { min = 0 max = 1 }
+		class = "pc_broken"
+		size = { min = 10 max = 15 }
+		init_effect = { prevent_anomaly = yes }
+	}
+	change_orbit = 30
+	planet = {
+		count = { min = 0 max = 1 }
+		class = "pc_barren_cold"
+		size = { min = 10 max = 20 }
+	}
+	init_effect = {
+		spawn_megastructure = {
+			type = lgate_base
+			orbit_angle = 225
+			orbit_distance = 30
+			location = solar_system
+		}
+	}
+}
+
+# L-Cluster Entrance
+distantstars_init_01 = {
+	class = "rl_standard_stars"
+	name = "NAME_Final_Egress"
+	usage = misc_system_init
+	usage_odds = 0
+	asteroid_belt = {
+		type = rocky_asteroid_belt
+		radius = 190
+	}
+	flags = { hostile_system lcluster lcluster1 lcluster_lgate }
+	planet = {
+		name = "NAME_Final_Egress"
+		class = "pc_g_star"
+		orbit_distance = 0
+		orbit_angle = 1
+		size = 30
+		has_ring = no
+	}
+
+	change_orbit = 45
+	planet = {
+		name = "NAME_Sel-Ufaan"
+		class = "pc_shattered"
+		orbit_distance = 40
+		orbit_angle = 15
+		size = 10
+		has_ring = no
+	}
+	planet = {
+		name = "NAME_Ten-Aard-Shel"
+		class = "pc_gray_goo"
+		orbit_distance = 25
+		orbit_angle = 125
+		size = 20
+		has_ring = no
+	}
+	planet = {
+		name = "NAME_Diim-Fu-Rem"
+		class = "pc_shattered"
+		orbit_distance = 25
+		orbit_angle = 120
+		size = 16
+		starting_planet = yes
+		has_ring = no
+		deposit_blockers = none
+		modifiers = none
+		flags = { planet_earth }
+		init_effect = { prevent_anomaly = yes }
+		moon = {
+			name = "NAME_Dora-Fu-Rem"
+			class = "pc_broken"
+			size = { min = 8 max = 22 }
+			orbit_distance = 12
+			orbit_angle = 40
+			has_ring = no
+			entity = "cold_barren_planet_luna_entity"
+		}
+	}
+	planet = {
+		name = "NAME_Naal-Di-Kor"
+		class = "pc_shattered"
+		orbit_distance = 25
+		orbit_angle = 60
+		size = 13
+		has_ring = no
+	}
+	planet = {
+		name = "NAME_Tao-Enar-Vi"
+		class = "pc_asteroid"
+		orbit_distance = 30
+		orbit_angle = -210
+		size = 5
+		has_ring = no
+	}
+	planet = {
+		name = "NAME_Tao-Fun-Vi"
+		class = "pc_asteroid"
+		orbit_distance = 0
+		orbit_angle = -95
+		size = 5
+		has_ring = no
+	}
+	planet = {
+		name = "NAME_Tao-Arl-Vi"
+		class = "pc_asteroid"
+		orbit_distance = 0
+		orbit_angle = 285
+		size = 5
+		has_ring = no
+	}
+	planet = {
+		name = "NAME_Tao-Got-Vi"
+		class = "pc_asteroid"
+		orbit_distance = 0
+		orbit_angle = -80
+		size = 5
+		has_ring = no
+	}
+	planet = {
+		name = "NAME_Gol-Unda-Fiir"
+		class = "pc_gas_giant"
+		orbit_distance = 40
+		orbit_angle = -160
+		size = 35
+		has_ring = no
+		change_orbit = 6
+		moon = {
+			name = "NAME_Dora-Enar-Fiir"
+			class = "pc_barren_cold"
+			size = { min = 8 max = 22 }
+			orbit_distance = 10
+			orbit_angle = 110
+			has_ring = no
+		}
+		moon = {
+			name = "NAME_Dora-Fun-Fiir"
+			class = "pc_shattered"
+			size = { min = 8 max = 22 }
+			orbit_distance = 4
+			orbit_angle = 100
+			has_ring = no
+		}
+		moon = {
+			name = "NAME_Dora-Arl-Fiir"
+			class = "pc_frozen"
+			size = { min = 8 max = 22 }
+			orbit_distance = 4
+			orbit_angle = 80
+			has_ring = no
+		}
+		moon = {
+			name = "NAME_Dora-Got-Fiir"
+			class = "pc_gray_goo"
+			size = { min = 8 max = 22 }
+			orbit_distance = 4
+			orbit_angle = -155
+			has_ring = no
+		}
+	}
+	planet = {
+		name = "NAME_Gol-Umn-Toor"
+		class = "pc_gas_giant"
+		orbit_distance = 25
+		orbit_angle = 170
+		size = 30
+		has_ring = yes
+		entity = "gas_giant_05_entity"
+		change_orbit = 7
+		moon = {
+			name = "NAME_Dora-Enar-Toor"
+			class = "pc_gray_goo"
+			size = { min = 8 max = 22 }
+			orbit_distance = 12
+			orbit_angle = 320
+			has_ring = no
+		}
+	}
+	planet = {
+		name = "NAME_Gol-Salm-Ri"
+		class = "pc_gas_giant"
+		orbit_distance = 25
+		orbit_angle = 125
+		size = 20
+		has_ring = no
+		entity = "gas_giant_03_entity"
+	}
+	planet = {
+		name = "NAME_Gol-Mel-Rood"
+		class = "pc_gas_giant"
+		orbit_distance = 25
+		orbit_angle = -195
+		size = 20
+		has_ring = no
+		entity = "gas_giant_02_entity"
+		change_orbit = 4
+		moon = {
+			name = "NAME_Dora-Enar-Rood"
+			class = "pc_broken"
+			size = { min = 8 max = 22 }
+			orbit_distance = 7
+			orbit_angle = 115
+			has_ring = no
+		}
+	}
+
+	init_effect = {
+		spawn_megastructure = {
+			type = lgate_base
+			orbit_angle = 225
+			orbit_distance = 360
+			location = solar_system
+		}
+		save_global_event_target_as = lcluster1
+	}
+}
+
+distantstars_init_02 = {
+	class = "rl_binary_stars"
+	asteroid_belt = {
+		type = rocky_asteroid_belt
+		radius = 125
+	}
+	asteroid_belt = {
+		type = icy_asteroid_belt
+		radius = 240
+	}
+	usage = misc_system_init
+	usage_odds = 0
+	flags = { hostile_system lcluster lcluster2 }
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 25
+		orbit_angle = 1
+		size = { min = 20 max = 30 }
+		has_ring = no
+	}
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 0
+		size = { min = 15 max = 25 }
+		has_ring = no
+	}
+	change_orbit = 30
+	planet = {
+		class = pc_broken
+		orbit_distance = 20
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_gray_goo
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	change_orbit = 25
+	planet = {
+		count = { min = 1 max = 4 }
+		class = pc_asteroid
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_gray_goo
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_gas_giant
+		orbit_distance = 30
+		orbit_angle = { min = 90 max = 270 }
+		size = 35
+		change_orbit = 11
+		moon = {
+			class = pc_broken
+			orbit_angle = { min = 90 max = 270 }
+			orbit_distance = 5
+		}
+	}
+	planet = {
+		class = pc_shattered
+		orbit_distance = 30
+		orbit_angle = { min = 90 max = 270 }
+	}
+	change_orbit = 30
+	planet = {
+		count = { min = 1 max = 4 }
+		class = pc_ice_asteroid
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	init_effect = {
+		save_global_event_target_as = lcluster2
+	}
+}
+
+distantstars_init_03 = {
+	class = "rl_standard_stars"
+	usage = misc_system_init
+	usage_odds = 0
+	flags = { hostile_system lcluster lcluster3 }
+
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 0
+		orbit_angle = 1
+		size = { min = 20 max = 30 }
+		has_ring = no
+	}
+
+	change_orbit = 70
+	planet = {
+		class = pc_shattered
+		orbit_distance = 10
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_broken
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_shattered
+		orbit_distance = 30
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_broken
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_gray_goo
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		count = { min = 1 max = 2 }
+		orbit_distance = 35
+		class = pc_gas_giant
+		orbit_angle = { min = 90 max = 270 }
+		size = 25
+		change_orbit = @base_moon_distance
+		moon = {
+			count = { min = 1 max = 3 }
+			size = { min = 8 max = 20 }
+			orbit_angle = { min = 90 max = 270 }
+			orbit_distance = 6
+		}
+	}
+	init_effect = {
+		save_global_event_target_as = lcluster3
+	}
+}
+
+distantstars_init_04 = {
+	class = "rl_standard_stars"
+	asteroid_belt = {
+		type = rocky_asteroid_belt
+		radius = 120
+	}
+	usage = misc_system_init
+	usage_odds = 0
+	flags = { hostile_system lcluster lcluster4 }
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 0
+		orbit_angle = 1
+		size = { min = 20 max = 30 }
+		has_ring = no
+	}
+	change_orbit = 120
+	planet = {
+		count = { min = 3 max = 6 }
+		class = pc_asteroid
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	change_orbit = -80
+	planet = {
+		class = pc_shattered
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_gray_goo
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	change_orbit = 80
+	planet = {
+		class = pc_gray_goo
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_broken
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	init_effect = {
+		save_global_event_target_as = lcluster4
+	}
+}
+
+distantstars_init_05 = {
+	class = "sc_trinary_2"
+	flags = { hostile_system lcluster lcluster5 graygoo_factory_system }
+	usage = misc_system_init
+	usage_odds = 0
+	asteroid_belt = {
+		type = rocky_asteroid_belt
+		radius = 185
+	}
+	planet = {
+		class = star
+		orbit_distance = 60
+		orbit_angle = 90
+		size = 30
+		has_ring = no
+		flags = { main_star }
+	}
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 0
+		orbit_angle = 135
+		size = 30
+		has_ring = no
+	}
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 0
+		orbit_angle = 90
+		size = 30
+		has_ring = no
+	}
+	planet = {
+		class = "pc_gray_goo"
+		orbit_distance = 85
+		orbit_angle = 40
+		size = 25
+		has_ring = no
+	}
+	change_orbit = 40
+	planet = {
+		count = { min = 2 max = 4 }
+		class = pc_asteroid
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = "pc_gas_giant"
+		orbit_distance = 40
+		orbit_angle = 165
+		size = 32
+		has_ring = no
+		moon = {
+			class = "pc_gray_goo"
+			size = 20
+			orbit_angle = { min = 90 max = 270 }
+			orbit_distance = 20
+		}
+	}
+	planet = {
+		class = "pc_gray_goo"
+		orbit_distance = 45
+		orbit_angle = 165
+		size = 18
+		has_ring = no
+	}
+	init_effect = {
+		save_global_event_target_as = lcluster_factory_system
+	}
+}
+
+# EXTRAS
+distantstars_init_01b = {
+	class = "rl_trinary_stars"
+	asteroid_belt = {
+		type = rocky_asteroid_belt
+		radius = 140
+	}
+	usage = misc_system_init
+	usage_odds = 0
+	flags = { hostile_system lcluster lcluster1b }
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 25
+		orbit_angle = 0
+		size = { min = 20 max = 30 }
+		has_ring = no
+	}
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = { min = 0 max = 20 }
+		orbit_angle = 120
+		size = { min = 25 max = 30 }
+		has_ring = no
+	}
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = { min = 0 max = 20 }
+		orbit_angle = 120
+		size = { min = 25 max = 30 }
+		has_ring = no
+	}
+	change_orbit = 90
+	planet = {
+		count = { min = 3 max = 6 }
+		class = pc_asteroid
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	change_orbit = -60
+	planet = {
+		class = pc_gray_goo
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_broken
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	change_orbit = 80
+	planet = {
+		class = pc_shattered
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_shattered
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	init_effect = {
+		save_global_event_target_as = lcluster1b
+	}
+}
+
+# EXTRAS
+distantstars_init_02b = {
+	class = "rl_binary_stars"
+	asteroid_belt = {
+		type = rocky_asteroid_belt
+		radius = 135
+	}
+	usage = misc_system_init
+	usage_odds = 0
+	flags = { hostile_system lcluster lcluster2b }
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 25
+		orbit_angle = 0
+		size = { min = 30 max = 35 }
+		has_ring = no
+	}
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 0
+		size = { min = 15 max = 25 }
+		has_ring = no
+	}
+	change_orbit = 110
+	planet = {
+		count = { min = 3 max = 6 }
+		class = pc_asteroid
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	change_orbit = -80
+	planet = {
+		class = pc_gray_goo
+		orbit_distance = 30
+		orbit_angle = { min = 90 max = 270 }
+	}
+	change_orbit = 90
+	planet = {
+		class = pc_shattered
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_broken
+		orbit_distance = 30
+		orbit_angle = { min = 90 max = 270 }
+	}
+	init_effect = {
+		save_global_event_target_as = lcluster2b
+	}
+}
+
+# EXTRAS
+distantstars_init_03b = {
+	class = "rl_standard_stars"
+	asteroid_belt = {
+		type = rocky_asteroid_belt
+		radius = 120
+	}
+	usage = misc_system_init
+	usage_odds = 0
+	flags = { hostile_system lcluster lcluster3b }
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 0
+		orbit_angle = 1
+		size = { min = 20 max = 30 }
+		has_ring = no
+	}
+	change_orbit = 120
+	planet = {
+		count = { min = 3 max = 6 }
+		class = pc_asteroid
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	change_orbit = -70
+	planet = {
+		class = pc_shattered
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_broken
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	change_orbit = 70
+	planet = {
+		class = pc_gray_goo
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_gas_giant
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_gray_goo
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	init_effect = {
+		save_global_event_target_as = lcluster3b
+	}
+}
+
+# EXTRAS
+distantstars_init_04b = {
+	class = "rl_standard_stars"
+	usage = misc_system_init
+	usage_odds = 0
+	flags = { hostile_system lcluster lcluster4b }
+	planet = {
+		count = 1
+		class = star
+		orbit_distance = 0
+		orbit_angle = 1
+		size = { min = 20 max = 30 }
+		has_ring = no
+	}
+	change_orbit = 50
+	planet = {
+		class = pc_broken
+		orbit_distance = 0
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_shattered
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_shattered
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_gray_goo
+		orbit_distance = 30
+		orbit_angle = { min = 90 max = 270 }
+	}
+	planet = {
+		class = pc_barren_cold
+		orbit_distance = 25
+		orbit_angle = { min = 90 max = 270 }
+		change_orbit = @base_moon_distance
+		moon = {
+			class = "pc_frozen"
+			orbit_angle = { min = 90 max = 270 }
+		}
+	}
+	init_effect = {
+		save_global_event_target_as = lcluster4b
+	}
+}

--- a/distant_stars_overhaul_original/events/distant_stars_event.11000.txt
+++ b/distant_stars_overhaul_original/events/distant_stars_event.11000.txt
@@ -1,0 +1,229 @@
+namespace = distar
+
+# Spawn l-cluster (written by Dee Majek, bit optimized by FirePrince)
+country_event = {
+	id = distar.11000
+	hide_window = yes
+	is_triggered_only = yes
+	fire_only_once = yes
+
+	immediate = {
+		set_spawn_system_batch = begin
+		# batch-processes the spawn_system effects between "begin" and "end",
+		# so caches are recalculated only once rather than for every system spawned
+		# can also be used when removing and adding hyperlanes
+		no_scope = {
+			# makes system positions originate from galactic core
+			spawn_system = {
+				min_distance >= 550
+				max_distance <= 560
+				min_orientation_angle = 44
+				max_orientation_angle = 46
+				initializer = distantstars_init_01
+				hyperlane = no
+			}
+			if = { limit = { NOT = { exists = event_target:lcluster1 } }
+				random_system = {
+					limit = { has_star_flag = lcluster1 }
+					save_global_event_target_as = lcluster1
+				}
+			}
+			event_target:lcluster1 = {
+				spawn_system = {
+					min_distance >= 29
+					max_distance <= 31
+					min_orientation_angle = 24
+					max_orientation_angle = 66
+					initializer = distantstars_init_02
+					hyperlane = no
+					is_discovered = no
+				}
+				spawn_system = {
+					min_distance >= 29
+					max_distance <= 31
+					min_orientation_angle = 114
+					max_orientation_angle = 156
+					initializer = distantstars_init_03
+					hyperlane = no
+					is_discovered = no
+				}
+				spawn_system = {
+					min_distance >= 30
+					max_distance <= 60
+					min_orientation_angle = 340
+					max_orientation_angle = 20
+					initializer = distantstars_init_01b
+					hyperlane = no
+					is_discovered = no
+				}
+			}
+			if = { limit = { NOT = { exists = event_target:lcluster2 } }
+				random_system = {
+					limit = { has_star_flag = lcluster2 }
+					save_global_event_target_as = lcluster2
+				}
+			}
+			event_target:lcluster2 = {
+				spawn_system = {
+					min_distance >= 30
+					max_distance <= 60
+					min_orientation_angle = 0
+					max_orientation_angle = 40
+					initializer = distantstars_init_02b
+					hyperlane = no
+					is_discovered = no
+				}
+			}
+			if = { limit = { NOT = { exists = event_target:lcluster3 } }
+				random_system = {
+					limit = { has_star_flag = lcluster3 }
+					save_global_event_target_as = lcluster3
+				}
+			}
+			event_target:lcluster3 = {
+				spawn_system = {
+					min_distance >= 20
+					max_distance <= 30
+					min_orientation_angle = 24
+					max_orientation_angle = 66
+					initializer = distantstars_init_04
+					hyperlane = no
+					is_discovered = no
+				}
+				spawn_system = {
+					min_distance >= 10
+					max_distance <= 50
+					min_orientation_angle = 250
+					max_orientation_angle = 290
+					initializer = distantstars_init_03b
+					hyperlane = no
+					is_discovered = no
+				}
+			}
+			if = { limit = { NOT = { exists = event_target:lcluster4 } }
+				random_system = {
+					limit = { has_star_flag = lcluster4 }
+					save_global_event_target_as = lcluster4
+				}
+			}
+
+			event_target:lcluster4 = {
+				spawn_system = {
+					min_distance >= 5
+					max_distance <= 10
+					min_orientation_angle = 250
+					max_orientation_angle = 290
+					initializer = distantstars_init_05
+					hyperlane = no
+					is_discovered = no
+				}
+				spawn_system = {
+					min_distance >= 30
+					max_distance <= 60
+					min_orientation_angle = 20
+					max_orientation_angle = 160
+					initializer = distantstars_init_04b
+					hyperlane = no
+					is_discovered = no
+				}
+			}
+			# We need only one target for the same issue, so take the better instead of "lcluster5"
+			if = { limit = { NOT = { exists = event_target:lcluster_factory_system } }
+				random_system = {
+					limit = { has_star_flag = lcluster5 }
+					save_global_event_target_as = lcluster_factory_system
+				}
+			}
+		}
+
+		if = { limit = { NOT = { exists = event_target:lcluster1b } }
+			random_system = {
+				limit = { has_star_flag = lcluster1b }
+				save_global_event_target_as = lcluster1b
+			}
+		}
+		if = { limit = { NOT = { exists = event_target:lcluster2b } }
+			random_system = {
+				limit = { has_star_flag = lcluster2b }
+				save_global_event_target_as = lcluster2b
+			}
+		}
+		if = { limit = { NOT = { exists = event_target:lcluster3b } }
+			random_system = {
+				limit = { has_star_flag = lcluster3b }
+				save_global_event_target_as = lcluster3b
+			}
+		}
+		if = { limit = { NOT = { exists = event_target:lcluster4b } }
+			random_system = {
+				limit = { has_star_flag = lcluster4b }
+				save_global_event_target_as = lcluster4b
+			}
+		}
+
+		## Clear all hyperlanes to and within the cluster
+		every_system = {
+			limit = { has_star_flag = lcluster }
+			isolate_system = yes
+		}
+
+		## Add hyperlanes
+		event_target:lcluster_factory_system = {
+			add_hyperlane = {
+				from = event_target:lcluster_factory_system
+				to = event_target:lcluster4
+			}
+		}
+		event_target:lcluster4 = {
+			add_hyperlane = {
+				from = event_target:lcluster4
+				to = event_target:lcluster3
+			}
+			add_hyperlane = {
+				from = event_target:lcluster4
+				to = event_target:lcluster2
+			}
+			add_hyperlane = {
+				from = event_target:lcluster4
+				to = event_target:lcluster4b
+			}
+		}
+		event_target:lcluster3 = {
+			add_hyperlane = {
+				from = event_target:lcluster3
+				to = event_target:lcluster1
+			}
+			add_hyperlane = {
+				from = event_target:lcluster3
+				to = event_target:lcluster3b
+			}
+		}
+		event_target:lcluster2 = {
+			add_hyperlane = {
+				from = event_target:lcluster2
+				to = event_target:lcluster1
+			}
+			add_hyperlane = {
+				from = event_target:lcluster2
+				to = event_target:lcluster3
+			}
+			add_hyperlane = {
+				from = event_target:lcluster2
+				to = event_target:lcluster2b
+			}
+		}
+		event_target:lcluster1 = {
+			add_hyperlane = {
+				from = event_target:lcluster1
+				to = event_target:lcluster1b
+			}
+		}
+		event_target:lcluster1b = {
+			add_hyperlane = {
+				from = event_target:lcluster1b
+				to = event_target:lcluster2b
+			}
+		}
+		set_spawn_system_batch = end
+	}
+}


### PR DESCRIPTION
Optimizing for the L-Cluster initializing (which leads to a lag on creation). Every L-Cluster system is saved in a temporary global target, but only AFTER the full creation of the L-Cluster, where after that, EVERY system is scanned again for EVERY galaxy system (which is multiplication). I changed this to the common way on saving this systems immediately in the init_effect (so without needless 9 galaxy system scans). I feel a noticeable improvement now.
