### PR TITLE
Mining station changes and preliminary nanotech changes

### DIFF
--- a/distant_stars_overhaul_original/common/component_templates/nanite_weapons.txt
+++ b/distant_stars_overhaul_original/common/component_templates/nanite_weapons.txt
@@ -94,7 +94,7 @@ strike_craft_component_template = {
 	icon_frame = 1
 
 	tags = { weapon_type_strike_craft }
-	size_restriction = { dso_nanite_core dso_nanite_mothership dso_nanite_interdictor }
+	size_restriction = { dso_nanite_core dso_nanite_mothership dso_nanite_interdictor nanite_interdictor dso_true_nanite_mothership }
 
 	power = -60
 
@@ -147,7 +147,7 @@ weapon_component_template = {
 
 	component_set = "GG_ENERGY_MISSILE_NANITE"
 	projectile_gfx = "gatebuilder_torpedo"
-	size_restriction = { dso_nanite_core dso_nanite_mothership dso_nanite_interdictor }
+	size_restriction = { dso_nanite_core dso_nanite_mothership dso_nanite_interdictor nanite_interdictor dso_true_nanite_mothership }
 
 	tags = { weapon_type_energy }
 	ai_tags = { weapon_role_artillery artillery artillery_stealth energy_torpedoes energy_torpedoes_stealth }
@@ -199,7 +199,7 @@ weapon_component_template = {
 	tags = { weapon_type_kinetic }
 
 	component_set = "GG_BEAM_STATIC_X_NANITE"
-	size_restriction = { dso_nanite_core dso_nanite_mothership }
+	size_restriction = { dso_nanite_core dso_nanite_mothership dso_true_nanite_mothership }
 
 	projectile_gfx = "gatebuilder_titan_weapon"
 
@@ -249,7 +249,7 @@ weapon_component_template = {
 	tags = { weapon_type_kinetic }
 
 	component_set = "GG_BEAM_STATIC_NANITE"
-	size_restriction = { dso_nanite_core dso_nanite_mothership }
+	size_restriction = { dso_nanite_core dso_nanite_mothership dso_true_nanite_mothership }
 
 	projectile_gfx = "gatebuilder_titan_weapon"
 
@@ -293,7 +293,7 @@ weapon_component_template = {
 
 	prerequisites = { "tech_nanite_guns" }
 	component_set = "GG_NANITE_GUNS"
-	size_restriction = { dso_nanite_core dso_nanite_mothership dso_nanite_interdictor }
+	size_restriction = { dso_nanite_core dso_nanite_mothership dso_nanite_interdictor dso_true_nanite_mothership }
 
 	projectile_gfx = "mass_driver_s"
 	tags = { weapon_type_kinetic }
@@ -340,7 +340,7 @@ weapon_component_template = {
 
 	prerequisites = { "tech_nanite_guns" }
 	component_set = "GG_NANITE_GUNS"
-	size_restriction = { dso_nanite_core dso_nanite_mothership dso_nanite_interdictor }
+	size_restriction = { dso_nanite_core dso_nanite_mothership dso_nanite_interdictor dso_true_nanite_mothership }
 
 	projectile_gfx = "mass_driver_m"
 	tags = { weapon_type_kinetic }
@@ -387,7 +387,7 @@ weapon_component_template = {
 
 	prerequisites = { "tech_nanite_guns" }
 	component_set = "GG_NANITE_GUNS"
-	size_restriction = { dso_nanite_core dso_nanite_mothership dso_nanite_interdictor }
+	size_restriction = { dso_nanite_core dso_nanite_mothership dso_nanite_interdictor dso_true_nanite_mothership }
 
 	projectile_gfx = "mass_driver_l"
 	tags = { weapon_type_kinetic }

--- a/distant_stars_overhaul_original/common/deposits/bh_deposits.txt
+++ b/distant_stars_overhaul_original/common/deposits/bh_deposits.txt
@@ -5,7 +5,7 @@ bh_harvested_planet_deposit_small = {
 			# physics_research = 4
 			# society_research = 4
 			# engineering_research = 4
-			unity = 5
+			unity = 25
 			minerals = 10
 			food = 15
 		}
@@ -23,7 +23,7 @@ bh_harvested_planet_deposit_moderate = {
 			# physics_research = 8
 			# society_research = 8
 			# engineering_research = 8
-			unity = 10
+			unity = 30
 			minerals = 20
 			food = 30
 		}
@@ -41,7 +41,7 @@ bh_harvested_planet_deposit_large = {
 			# physics_research = 15
 			# society_research = 15
 			# engineering_research = 15
-			unity = 20
+			unity = 40
 			minerals = 40
 			food = 60
 		}

--- a/distant_stars_overhaul_original/common/ship_sizes/nanite_mothership.txt
+++ b/distant_stars_overhaul_original/common/ship_sizes/nanite_mothership.txt
@@ -317,6 +317,193 @@ dso_nanite_mothership = {
 		nanites = 15
 	}
 }
+dso_true_nanite_mothership = {
+	formation_priority = @titan_formation_priority
+	entity = "gatebuilder_01_mothership_entity"
+	max_speed = @speed_slow
+	acceleration = 0.2
+	rotation_speed = 0.15
+	collision_radius = @titan_collision_radius
+	max_hitpoints = @titan_hp
+	modifier = {
+		ship_evasion_add = @titan_evasion
+		# ship_piracy_suppression_add = 4
+	}
+	size_multiplier = 16
+	fleet_slot_size = 8
+	section_slots = { "bow" = { locator = "part1" } "mid" = { locator = "part2" } "stern" = { locator = "part3" } }
+	num_target_locators = 8
+	is_space_station = no
+	icon = ship_size_military_16
+	base_buildtime = @titan_build_time
+	can_have_federation_design = no
+	enable_default_design = no
+
+	default_behavior = artillery
+
+	prerequisites = { "tech_nanite_mothership" }
+	
+	potential_country = {
+		has_tradition = tr_nanotech_4
+	}
+
+	combat_disengage_chance = 1.25
+
+	class = shipclass_military
+
+	is_designable = yes
+	selectable = { has_apocalypse_dlc = yes }
+
+	construction_type = starbase_shipyard
+	required_component_set = "power_core"
+	required_component_set = "ftl_components"
+	required_component_set = "thruster_components"
+	required_component_set = "sensor_components"
+	required_component_set = "combat_computers"
+	
+	
+	potential_construction = {
+		OR = {
+			AND = {
+				is_scope_type = starbase
+				NOT = { has_starbase_size = juggernaut }
+			}
+			AND = {
+				is_scope_type = megastructure
+				OR = {
+					is_megastructure_type = mega_shipyard_3
+					is_megastructure_type = mega_shipyard_restored
+				}
+			}
+			AND = {
+					is_scope_type = starbase 
+					owner = {
+						any_owned_ship = { 
+							has_component = DCV_MAINTENANCE_CREW
+							distance = {
+								source = root
+								same_solar_system = yes
+							}
+						}
+					}
+				}
+		}
+	}
+	
+	possible_construction = {
+		custom_tooltip = {
+			fail_text = starbase_citadel_trigger
+			OR = {
+				AND = {
+					is_scope_type = megastructure
+					OR = {
+						is_megastructure_type = mega_shipyard_3
+						is_megastructure_type = mega_shipyard_restored
+					}
+				}
+				AND = {
+					is_scope_type = starbase
+					has_starbase_size >= starbase_citadel
+				}
+				AND = {
+					is_scope_type = starbase 
+					owner = {
+						any_owned_ship = { 
+							has_component = DCV_MAINTENANCE_CREW
+							distance = {
+								source = root
+								same_solar_system = yes
+							}
+						}
+					}
+				}
+			}
+		}
+		custom_tooltip = {
+			fail_text = starbase_nanite_yards_trigger
+			OR = {
+				AND = {
+					is_scope_type = megastructure
+					OR = {
+						is_megastructure_type = mega_shipyard_3
+						is_megastructure_type = mega_shipyard_restored
+					}
+				}
+				AND = {
+					is_scope_type = starbase
+					has_starbase_building = orbital_nanite_shipyard
+				}
+				AND = {
+					is_scope_type = starbase 
+					owner = {
+						any_owned_ship = { 
+							has_component = DCV_MAINTENANCE_CREW
+							distance = {
+								source = root
+								same_solar_system = yes
+							}
+						}
+					}
+				}
+			}
+		}
+		custom_tooltip = {
+			fail_text = starbase_titan_yards_trigger
+			OR = {
+				AND = {
+					is_scope_type = megastructure
+					OR = {
+						is_megastructure_type = mega_shipyard_3
+						is_megastructure_type = mega_shipyard_restored
+					}
+				}
+				AND = {
+					is_scope_type = starbase
+					has_starbase_building = titan_yards
+				}
+				AND = {
+					is_scope_type = starbase 
+					owner = {
+						any_owned_ship = { 
+							has_component = DCV_MAINTENANCE_CREW
+							distance = {
+								source = root
+								same_solar_system = yes
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	# empire_limit = {
+	#	base = 1
+	#	max = 20
+	#	naval_cap_div = 200
+	#	show = {
+	#		is_scope_valid = yes
+	#		has_technology = tech_titans
+	#	}
+	#}
+	ai_ship_data = {
+		min = 1
+		max = 20
+	}
+	
+	components_add_to_cost = no
+	resources = {
+		category = ships
+		cost = {
+			nanites = 37500
+			alloys = 250
+		}
+	}
+
+	min_upgrade_cost = {
+		nanites = 15
+	}
+}
 
 dso_nanite_core = {
 	formation_priority = @juggernaut_formation_priority
@@ -430,14 +617,6 @@ dso_nanite_core = {
 		}
 	}
 
-	# empire_limit = {
-	#	base = 1
-	#	max = 1
-	#	show = {
-	#		is_scope_valid = yes
-	#		has_technology = tech_juggernaut
-	#	}
-	#}
 	ai_ship_data = {
 		min = 1
 		max = 1


### PR DESCRIPTION
1. Increases base output of all harvesters by 20

2. Makes nanite weaponry compatible with base nanite ships and allows it to be used for upcoming no upkeep mothship

3. Adds new ship size (to be finished mothership with no upkeep)